### PR TITLE
feat: `alignment_size` function for aligned types

### DIFF
--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -159,9 +159,14 @@ impl<A: Alignment> AlignedBytes<A> {
     }
 
     /// Return the size of the alignment in bytes.
+    ///
+    /// ## Note
+    /// This does not reflect the actual maximal alignment,
+    /// only the guarantee provided by `A`, which may be lower than
+    /// the actual alignment.
     #[must_use]
     #[inline(always)]
-    pub fn alignment_size() -> usize {
+    pub fn alignment_size(&self) -> usize {
         A::size()
     }
 
@@ -281,5 +286,12 @@ mod tests {
     fn new_initialize_is_aligned() {
         let bytes: AlignedBytes<alignment::TwoTo<15>> = AlignedBytes::new_initialize(2137, |_| 1);
         assert_aligned(bytes.as_ptr(), 2usize.pow(15));
+    }
+
+    #[test]
+    fn alignment_size_equal_to_alignment_type() {
+        let bytes: AlignedBytes<alignment::TwoTo<7>> = AlignedBytes::new_zeroed(1024);
+
+        assert_eq!(128, bytes.alignment_size());
     }
 }

--- a/src/iterators.rs
+++ b/src/iterators.rs
@@ -53,6 +53,18 @@ impl<A: Alignment> AlignedBlock<A> {
     pub fn is_empty(&self) -> bool {
         self.slice.is_empty()
     }
+
+    /// Return the size of the alignment in bytes. Equal to [`A::size()`](`Alignment::size`).
+    ///
+    /// ## Note
+    /// This does not reflect the actual maximal alignment,
+    /// only the guarantee provided by `A`, which may be lower than
+    /// the actual alignment.
+    #[must_use]
+    #[inline(always)]
+    pub fn alignment_size(&self) -> usize {
+        A::size()
+    }
 }
 
 impl<'a, A: Alignment> Iterator for AlignedBlockIterator<'a, A> {
@@ -90,3 +102,17 @@ impl<'a, A: Alignment> Iterator for AlignedBlockIterator<'a, A> {
 impl<A: Alignment> ExactSizeIterator for AlignedBlockIterator<'_, A> {}
 
 impl<A: Alignment> FusedIterator for AlignedBlockIterator<'_, A> {}
+
+#[cfg(test)]
+mod tests {
+    use crate::{alignment, AlignedBytes};
+
+    #[test]
+    fn alignment_size_equal_to_alignment_type() {
+        let bytes: AlignedBytes<alignment::TwoTo<7>> = AlignedBytes::new_zeroed(1024);
+        let mut iter = bytes.iter_blocks();
+        let block = iter.next().unwrap();
+
+        assert_eq!(128, block.alignment_size());
+    }
+}

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -53,6 +53,18 @@ impl<A: Alignment> AlignedSlice<A> {
         unsafe { std::mem::transmute(&self[offset_in_bytes..]) }
     }
 
+    /// Return the size of the alignment in bytes.
+    ///
+    /// ## Note
+    /// This does not reflect the actual maximal alignment,
+    /// only the guarantee provided by `A`, which may be lower than
+    /// the actual alignment.
+    #[must_use]
+    #[inline(always)]
+    pub fn alignment_size(&self) -> usize {
+        A::size()
+    }
+
     /// Return an iterator over consecutive aligned blocks of the slice.
     #[must_use]
     #[inline]
@@ -232,7 +244,7 @@ impl<A: Alignment> Default for &mut AlignedSlice<A> {
 #[cfg(test)]
 mod tests {
     use crate::test::assert_aligned;
-    use crate::{alignment, AlignedSlice};
+    use crate::{alignment, AlignedBytes, AlignedSlice};
 
     #[test]
     fn empty_slice_is_aligned() {
@@ -244,5 +256,13 @@ mod tests {
     fn empty_mut_slice_is_aligned() {
         let empty: &mut AlignedSlice<alignment::Eight> = Default::default();
         assert_aligned(empty.as_ptr(), 8);
+    }
+
+    #[test]
+    fn alignment_size_equal_to_alignment_type() {
+        let bytes: AlignedBytes<alignment::TwoTo<7>> = AlignedBytes::new_zeroed(1024);
+        let slice: &AlignedSlice<alignment::TwoTo<7>> = &bytes;
+
+        assert_eq!(128, slice.alignment_size());
     }
 }


### PR DESCRIPTION
Allows getting the `alignment` size as a method instead of static.

Refs: #29