### PR TITLE
feat: make `Default` conform to strict provenance

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,6 +3,7 @@
         "crev",
         "dealloc",
         "docsrs",
+        "miri",
         "powerset",
         "repr",
         "Unsafety"

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -261,7 +261,13 @@ impl<A: Alignment> Default for AlignedBytes<A> {
         // but for `A::size()` alignment.
         // The only requirement of new_unchecked is the pointer being not-null, and A::size() must be > 0.
         let bytes_ptr = unsafe {
+            // Use strict pointer functions if enabled.
+            // See https://github.com/V0ldek/aligners/issues/34
+            #[cfg(miri)]
+            let raw_ptr = std::ptr::invalid_mut(A::size());
+            #[cfg(not(miri))]
             let raw_ptr = A::size() as *mut u8;
+
             NonNull::new_unchecked(raw_ptr)
         };
         Self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,7 @@
 // Same goes for the revolutionary "link to pointers documentation" feature.
 // (https://github.com/rust-lang/rust/issues/80896).
 #![cfg_attr(docsrs, feature(intra_doc_pointers))]
+#![cfg_attr(miri, feature(strict_provenance))]
 
 //! Structures providing guarantees on byte sequence alignment.
 //!


### PR DESCRIPTION
Related: #34