### PR TITLE
remove cron CI and add manual trigger

### DIFF
--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -2,10 +2,9 @@
 name: Miri
 
 on:
+  workflow_dispatch:
   push:
     branches: [ main, ci ]
-  schedule:
-    - cron: '0 0 * * *'
 
 jobs:
   miri:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,12 +2,11 @@
 name: Rust
 
 on:
+  workflow_dispatch:
   push:
     branches: [ main ]
   pull_request:
     branches: [ main ]
-  schedule:
-    - cron: '0 0 * * *'
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
CI crons got disabled due to inactivity in the repo and it seems to have broken the required checks for PRs.

Removing the cron will prevent them from being disabled, and the manual trigger should allow running them on demand if something breaks with a PR again.